### PR TITLE
sed command with -i option failing on Mac

### DIFF
--- a/deploy-grafana.sh
+++ b/deploy-grafana.sh
@@ -47,7 +47,11 @@ function generate_ingressroute_yaml {
 generate_ingressroute_yaml
 
 echo "Set the correct quote sympbols in ingressroute.yaml"
-sed -i "s/'/\`/g" ingressroute.yaml
+if [ "$(uname -s)" == "Darwin" ]; then
+    sed -i "" "s/'/\`/g" ingressroute.yaml
+else
+    sed -i "s/'/\`/g" ingressroute.yaml
+fi
 
 echo "Deploying Traefik V2 IngressRoute and Middleware"
 kubectl --namespace $NAMESPACE apply -f ingressroute.yaml


### PR DESCRIPTION
I got the error below when I tried deploying Grafana on Mac(macOS Venture 13.3 (22E252) / Intel). 

```
Set the correct quote sympbols in ingressroute.yaml
sed: 1: "ingressroute.yaml": command i expects \ followed by text
```